### PR TITLE
Pulled in updated WASM

### DIFF
--- a/packages/compiler/src/data/lib.wasm.gz
+++ b/packages/compiler/src/data/lib.wasm.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6a84c4043248e40135750ead2eed9fe8a5c71b02aff189924076df887a2433a
-size 24407464
+oid sha256:0925b95b351fa061d4c60e326bbf5ad2198504f91cc15a69ab4bf151eecac76f
+size 16645974

--- a/packages/compiler/src/generatePages.ts
+++ b/packages/compiler/src/generatePages.ts
@@ -28,7 +28,7 @@ export async function generatePages({
   setInternalSetting("onPageComplete", onPageComplete);
 
   // Get the docs data from the spec
-  info("Parsing OpenAPI spec (ignore lock file errors printed below)");
+  info("Parsing OpenAPI spec (ignore gen.yaml file errors printed below)");
   const { data, docsCodeSamples } = await generateData({
     site,
     specContents,


### PR DESCRIPTION
Resolves https://linear.app/speakeasy/issue/OAPI-5179/remove-self-destruct-from-docs