### PR TITLE
Add package name to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "docsmd",
   "description": "API docs monorepo",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a name to the repo root `package.json`. NPM keeps generating a camel-cased package name to match the repo root when generating `package-lock.json` when I run locally versus the all lowercase name generated in CI. 