### PR TITLE
[OAPI-5582] Verify SDK generated with updated Speakeasy CLI version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11272,6 +11272,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
@@ -31877,6 +31884,7 @@
         "curl-generator": "^0.4.2",
         "esbuild": "^0.25.10",
         "js-yaml": "^4.1.0",
+        "semver": "^7.5.4",
         "tar": "^7.5.1",
         "zod": "^3.25.56"
       },
@@ -31886,6 +31894,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.15.17",
+        "@types/semver": "^7.7.1",
         "globals": "^16.3.0",
         "typescript": "^5.8.3"
       }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -43,12 +43,14 @@
     "curl-generator": "^0.4.2",
     "esbuild": "^0.25.10",
     "js-yaml": "^4.1.0",
+    "semver": "^7.5.4",
     "tar": "^7.5.1",
     "zod": "^3.25.56"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.15.17",
+    "@types/semver": "^7.7.1",
     "globals": "^16.3.0",
     "typescript": "^5.8.3"
   }


### PR DESCRIPTION
This PR adds verification to validate SDKs used to generate Code Examples were generated with a new enough version of the Speakeasy SDK that contains the necessary metadata. I am pulling the `speakeasyVersion` from the `workflow.lock` file because I noticed that in the example Glean typescript SDK we are using `workflow.yaml` contains `speakeasyVersion: latest` instead of a particular version number, but the lockfile contained the actual version number.

I placed this validation with the existing SDK artifact processing so that it happens after we have already have processed the SDK artifacts.